### PR TITLE
fix: rename Set to SwimSet

### DIFF
--- a/Sources/App/Controllers/StrokeController.swift
+++ b/Sources/App/Controllers/StrokeController.swift
@@ -1,0 +1,37 @@
+import Fluent
+import Vapor
+
+struct StrokeController: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        let strokes = routes.grouped("strokes")
+
+        strokes.get(use: self.index)
+        strokes.post(use: self.create)
+        strokes.group(":strokeID") { stroke in
+            stroke.delete(use: self.delete)
+        }
+    }
+
+    @Sendable
+    func index(req: Request) async throws -> [StrokeDTO] {
+        try await Stroke.query(on: req.db).all().map { $0.toDTO() }
+    }
+
+    @Sendable
+    func create(req: Request) async throws -> StrokeDTO {
+        let stroke = try req.content.decode(StrokeDTO.self).toModel()
+
+        try await stroke.save(on: req.db)
+        return stroke.toDTO()
+    }
+
+    @Sendable
+    func delete(req: Request) async throws -> HTTPStatus {
+        guard let stroke = try await Stroke.find(req.parameters.get("strokeID"), on: req.db) else {
+            throw Abort(.notFound)
+        }
+
+        try await stroke.delete(on: req.db)
+        return .noContent
+    }
+}

--- a/Sources/App/Controllers/SwimSetController.swift
+++ b/Sources/App/Controllers/SwimSetController.swift
@@ -1,0 +1,37 @@
+import Fluent
+import Vapor
+
+struct SwimSetController: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        let swimsets = routes.grouped("swimsets")
+
+        swimsets.get(use: self.index)
+        swimsets.post(use: self.create)
+        swimsets.group(":swimsetID") { swimset in
+            swimset.delete(use: self.delete)
+        }
+    }
+
+    @Sendable
+    func index(req: Request) async throws -> [SwimSetDTO] {
+        try await SwimSet.query(on: req.db).all().map { $0.toDTO() }
+    }
+
+    @Sendable
+    func create(req: Request) async throws -> SwimSetDTO {
+        let swimset = try req.content.decode(SwimSetDTO.self).toModel()
+
+        try await swimset.save(on: req.db)
+        return swimset.toDTO()
+    }
+
+    @Sendable
+    func delete(req: Request) async throws -> HTTPStatus {
+        guard let swimset = try await Workout.find(req.parameters.get("swimsetID"), on: req.db) else {
+            throw Abort(.notFound)
+        }
+
+        try await swimset.delete(on: req.db)
+        return .noContent
+    }
+}

--- a/Sources/App/DTOs/SwimSetDTO.swift
+++ b/Sources/App/DTOs/SwimSetDTO.swift
@@ -8,15 +8,15 @@
 import Fluent
 import Vapor
 
-struct SetDTO: Content {
+struct SwimSetDTO: Content {
     var id: UUID?
     var title: String?
     var distance: Int?
     var rest: Int?
     var reps: Int?
     
-    func toModel() -> Stroke {
-        let model = Stroke()
+    func toModel() -> SwimSet {
+        let model = SwimSet()
         
         model.id = self.id
         if let title = self.title {

--- a/Sources/App/Migrations/CreateSwimSet.swift
+++ b/Sources/App/Migrations/CreateSwimSet.swift
@@ -1,8 +1,8 @@
 import Fluent
 
-struct CreateSet: AsyncMigration {
+struct CreateSwimSet: AsyncMigration {
     func prepare(on database: Database) async throws {
-        try await database.schema("sets")
+        try await database.schema("swimsets")
             .id()
             .field("title", .string, .required)
             .field("distance", .int, .required)
@@ -12,6 +12,6 @@ struct CreateSet: AsyncMigration {
     }
 
     func revert(on database: Database) async throws {
-        try await database.schema("strokes").delete()
+        try await database.schema("swimsets").delete()
     }
 }

--- a/Sources/App/Models/SwimSet.swift
+++ b/Sources/App/Models/SwimSet.swift
@@ -1,8 +1,8 @@
 import Fluent
 import struct Foundation.UUID
 
-final class Set: Model, @unchecked Sendable {
-    static let schema = "sets"
+final class SwimSet: Model, @unchecked Sendable {
+    static let schema = "swimsets"
     
     @ID(key: .id)
     var id: UUID?
@@ -42,7 +42,7 @@ final class Set: Model, @unchecked Sendable {
         // self.workout_id = workout_id
     }
     
-    func toDTO() -> SetDTO {
+    func toDTO() -> SwimSetDTO {
         .init(
             id: self.id,
             title: self.$title.value,

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -24,7 +24,7 @@ public func configure(_ app: Application) async throws {
     // app.migrations.add(CreateSet())
     
     app.migrations.add(CreateWorkout())
-    app.migrations.add(CreateSet())
+    app.migrations.add(CreateSwimSet())
     app.migrations.add(CreateStroke())
 
     app.views.use(.leaf)

--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -11,7 +11,9 @@ func routes(_ app: Application) throws {
     }
 
 
-     try app.register(collection: WorkoutController())
+    try app.register(collection: WorkoutController())
+    try app.register(collection: SwimSetController())
+    try app.register(collection: StrokeController())
 
 
 //    app.post("workouts") {req -> EventLoopFuture<Workout> in


### PR DESCRIPTION
Why? Because "set" is a reserved keyword in Swift, and it is better to avoid using it as a type name.